### PR TITLE
Fibonacci cleanups

### DIFF
--- a/benchmark/fibonacci.casm
+++ b/benchmark/fibonacci.casm
@@ -40,13 +40,14 @@
 //  statement from your version.
 //
 
-CASM init foo
+CASM init main
 
-rule foo =
-    let n = 27 in {|
-        println("Fibonacci(" + dec(n) + ") using dynamic programming:")
+rule main =
+    let n = 27 in
+    {|
+        print("Fibonacci(" + dec(n) + ") using dynamic programming = ")
         call fibonacci(n)
-        println("=" + dec(f(n)))
+        println(dec(f(n)))
         program(self) := undef
     |}
 

--- a/benchmark/fibonacci_large.casm
+++ b/benchmark/fibonacci_large.casm
@@ -40,13 +40,14 @@
 //  statement from your version.
 //
 
-CASM init foo
+CASM init main
 
-rule foo =
-    let n = 7'500 in {|
-        println("Fibonacci(" + dec(n) + ") using dynamic programming:")
+rule main =
+    let n = 7'500 in
+    {|
+        print("Fibonacci(" + dec(n) + ") using dynamic programming = ")
         call fibonacci(n)
-        println("=" + dec(f(n)))
+        println(dec(f(n)))
         program(self) := undef
     |}
 


### PR DESCRIPTION
* Make the implementation more mathematical
* Use proper names instead of e.g. `foo`