### PR TITLE
Adjust error codes for argument size mismatch

### DIFF
--- a/test/definition/derived/error/too_few_arguments.casm
+++ b/test/definition/derived/error/too_few_arguments.casm
@@ -49,5 +49,5 @@ derived bar( x : Integer, y : Integer ) -> Integer =
     42
 
 rule foo =
-    let x = bar( 1 ) in //@ ERROR( 1313 )
+    let x = bar( 1 ) in //@ ERROR( 0503 )
         skip

--- a/test/definition/derived/error/too_much_arguments.casm
+++ b/test/definition/derived/error/too_much_arguments.casm
@@ -49,5 +49,5 @@ derived bar( x : Integer, y : Integer ) -> Integer =
     42
 
 rule foo =
-    let x = bar( 1, 2, 3 ) in //@ ERROR( 1313 )
+    let x = bar( 1, 2, 3 ) in //@ ERROR( 0503 )
         skip

--- a/test/definition/function/error/initially_too_few_arguments.casm
+++ b/test/definition/function/error/initially_too_few_arguments.casm
@@ -46,7 +46,7 @@
 CASM init foo
 
 function x : Integer * Integer -> Integer initially {
-    1 -> 42 //@ ERROR( 1312 )
+    1 -> 42 //@ ERROR( 0503 )
 }
 
 rule foo =

--- a/test/definition/function/error/initially_too_much_arguments.casm
+++ b/test/definition/function/error/initially_too_much_arguments.casm
@@ -46,7 +46,7 @@
 CASM init foo
 
 function x : Integer * Integer -> Integer initially {
-    ( 1, 2, 3 ) -> 42 //@ ERROR( 1312 )
+    ( 1, 2, 3 ) -> 42 //@ ERROR( 0503 )
 }
 
 rule foo =

--- a/test/definition/function/error/lookup_too_few_arguments.casm
+++ b/test/definition/function/error/lookup_too_few_arguments.casm
@@ -48,5 +48,5 @@ CASM init foo
 function x : Integer * Integer -> Integer
 
 rule foo =
-    let y = x( 1 ) in //@ ERROR( 1312 )
+    let y = x( 1 ) in //@ ERROR( 0503 )
         skip

--- a/test/definition/function/error/lookup_too_much_arguments.casm
+++ b/test/definition/function/error/lookup_too_much_arguments.casm
@@ -48,5 +48,5 @@ CASM init foo
 function x : Integer * Integer -> Integer
 
 rule foo =
-    let y = x( 1, 2, 3 ) in //@ ERROR( 1312 )
+    let y = x( 1, 2, 3 ) in //@ ERROR( 0503 )
         skip

--- a/test/rule/update/error/too_few_arguments.casm
+++ b/test/rule/update/error/too_few_arguments.casm
@@ -49,7 +49,7 @@ function y : Integer * Integer -> Integer
 
 rule foo =
 {
-    y( 1 ) := 42 //@ ERROR( 1312 )
+    y( 1 ) := 42 //@ ERROR( 0503 )
 
     program( self ) := undef
 }

--- a/test/rule/update/error/too_much_arguments.casm
+++ b/test/rule/update/error/too_much_arguments.casm
@@ -49,7 +49,7 @@ function y : Integer * Integer -> Integer
 
 rule foo =
 {
-    y( 1, 2, 3 ) := 42 //@ ERROR( 1312 )
+    y( 1, 2, 3 ) := 42 //@ ERROR( 0503 )
 
     program( self ) := undef
 }


### PR DESCRIPTION
The explicit arguments size mismatch codes for rule, derived, ... has been dropped in favor of a generic one.