### PR TITLE
IdentifierPath: fixed incorrect namespace delimiter usage in unit tests

### DIFF
--- a/test/definition/enumeration/error/implicit_namespace_when_type_is_unknown.casm
+++ b/test/definition/enumeration/error/implicit_namespace_when_type_is_unknown.casm
@@ -48,7 +48,7 @@ enumeration Color = { Red, Green, Blue }
 
 rule foo =
 {
-    let c = .Red in //@ERROR( 0000 )
+    let c = ::Red in //@ERROR( 0000 )
         skip
 
 }

--- a/test/definition/enumeration/implicit_name_space.casm
+++ b/test/definition/enumeration/implicit_name_space.casm
@@ -46,18 +46,18 @@ enumeration Color = { Red, Green, Blue }
 
 rule foo =
 {
-    let c : Color = .Red in // Color namespace from type of c
+    let c : Color = ::Red in // Color namespace from type of c
         skip
 
-    let c = Color.Green in
+    let c = Color::Green in
         case c of // cases should use Color namespace of c
         {
-            .Red: assert(false)
-            .Green: assert(true)
-            .Blue: assert(false)
+            ::Red: assert(false)
+            ::Green: assert(true)
+            ::Blue: assert(false)
         }
 
-    let c = Color.Blue in
-        if c != .Blue then
+    let c = Color::Blue in
+        if c != ::Blue then
             assert(false)
 }

--- a/test/definition/enumeration/implicit_name_space_with_function.casm
+++ b/test/definition/enumeration/implicit_name_space_with_function.casm
@@ -44,19 +44,19 @@ CASM init foo
 
 enumeration Color = { Red, Green, Blue }
 
-function colorFunction : -> Color initially { .Blue } // Color namespace from type of colorFunction
+function colorFunction : -> Color initially { ::Blue } // Color namespace from type of colorFunction
 
 rule foo =
 {
     case colorFunction of // cases should use Color namespace of colorFunction
     {
-        .Red: assert(false)
-        .Green: assert(false)
-        .Blue: assert(true)
+        ::Red: assert(false)
+        ::Green: assert(false)
+        ::Blue: assert(true)
     }
 
-    if colorFunction != .Blue then
+    if colorFunction != ::Blue then
         assert(false)
 
-    colorFunction := .Red // Color namespace from type of colorFunction
+    colorFunction := ::Red // Color namespace from type of colorFunction
 }

--- a/test/definition/enumeration/with_namespace.casm
+++ b/test/definition/enumeration/with_namespace.casm
@@ -46,10 +46,10 @@ enumeration Color = { Red, Green, Blue }
 
 rule foo =
 {
-    let c = Color.Red in
+    let c = Color::Red in
         skip
 
-    let c : Color = Color.Red in
+    let c : Color = Color::Red in
         skip
 
 }

--- a/test/expression/typecasting/binary/error/enumeration.casm
+++ b/test/expression/typecasting/binary/error/enumeration.casm
@@ -46,12 +46,12 @@ enumeration myEnum = { one, two, three }
 
 rule foo =
 {
-    let x : myEnum = myEnum.two in
+    let x : myEnum = myEnum::two in
         assert( x as Binary'1 = 0b0 ) //@ ERROR( 1700 )
 
-    let x : myEnum = myEnum.two in
+    let x : myEnum = myEnum::two in
         assert( x as Binary'8 = 0b0 ) //@ ERROR( 1700 )
 
-    let x : myEnum = myEnum.two in
+    let x : myEnum = myEnum::two in
         assert( x as Binary'23 = 0b0 ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/boolean/error/enumeration.casm
+++ b/test/expression/typecasting/boolean/error/enumeration.casm
@@ -49,6 +49,6 @@ enumeration myEnum = { one, two, three }
 
 rule foo =
 {
-    let x : myEnum = myEnum.one in
+    let x : myEnum = myEnum::one in
     	assert( x as Boolean = false ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/decimal/error/enumeration.casm
+++ b/test/expression/typecasting/decimal/error/enumeration.casm
@@ -46,6 +46,6 @@ enumeration myEnum = { one, two, three }
 
 rule foo =
 {
-    let x : myEnum = myEnum.two in
+    let x : myEnum = myEnum::two in
         assert( x as Decimal = 0.0 ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/enumeration/enumeration.casm
+++ b/test/expression/typecasting/enumeration/enumeration.casm
@@ -46,8 +46,8 @@ enumeration myEnum = { one, two, three }
 
 rule foo =
 {
-    let x : myEnum = undef        in assert( x as myEnum = undef )
-    let x : myEnum = myEnum.one   in assert( x as myEnum = myEnum.one )
-    let x : myEnum = myEnum.two   in assert( x as myEnum = myEnum.two )
-    let x : myEnum = myEnum.three in assert( x as myEnum = myEnum.three )
+    let x : myEnum = undef         in assert( x as myEnum = undef )
+    let x : myEnum = myEnum::one   in assert( x as myEnum = myEnum::one )
+    let x : myEnum = myEnum::two   in assert( x as myEnum = myEnum::two )
+    let x : myEnum = myEnum::three in assert( x as myEnum = myEnum::three )
 }

--- a/test/expression/typecasting/enumeration/error/binary.casm
+++ b/test/expression/typecasting/enumeration/error/binary.casm
@@ -47,5 +47,5 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x : Binary'1 = 0b1 in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/enumeration/error/boolean.casm
+++ b/test/expression/typecasting/enumeration/error/boolean.casm
@@ -47,5 +47,5 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x : Boolean = true in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/enumeration/error/decimal.casm
+++ b/test/expression/typecasting/enumeration/error/decimal.casm
@@ -47,5 +47,5 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x : Decimal = 1.0 in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/enumeration/error/file.casm
+++ b/test/expression/typecasting/enumeration/error/file.casm
@@ -47,7 +47,7 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x = bar in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }
 
 function bar : -> File< String >

--- a/test/expression/typecasting/enumeration/error/funcref.casm
+++ b/test/expression/typecasting/enumeration/error/funcref.casm
@@ -47,7 +47,7 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x : FuncRef< -> Integer > = @bar in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }
 
 function bar : -> Integer

--- a/test/expression/typecasting/enumeration/error/integer.casm
+++ b/test/expression/typecasting/enumeration/error/integer.casm
@@ -47,5 +47,5 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x : Integer = 1 in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/enumeration/error/list.casm
+++ b/test/expression/typecasting/enumeration/error/list.casm
@@ -47,5 +47,5 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x : List< Integer > = [ 1, 10, 2, 20 ] in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/enumeration/error/port.casm
+++ b/test/expression/typecasting/enumeration/error/port.casm
@@ -47,7 +47,7 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x = bar in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }
 
 function bar : -> Port< String >

--- a/test/expression/typecasting/enumeration/error/range.casm
+++ b/test/expression/typecasting/enumeration/error/range.casm
@@ -47,5 +47,5 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x : Range< Integer > = [ 1 .. 10 ] in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/enumeration/error/rational.casm
+++ b/test/expression/typecasting/enumeration/error/rational.casm
@@ -47,5 +47,5 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x : Rational = 0r0/1 in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/enumeration/error/ruleref.casm
+++ b/test/expression/typecasting/enumeration/error/ruleref.casm
@@ -47,7 +47,7 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x : RuleRef< -> Void > = @bar in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }
 
 rule bar = skip

--- a/test/expression/typecasting/enumeration/error/string.casm
+++ b/test/expression/typecasting/enumeration/error/string.casm
@@ -47,5 +47,5 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x : String = "one" in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/enumeration/error/tuple.casm
+++ b/test/expression/typecasting/enumeration/error/tuple.casm
@@ -47,5 +47,5 @@ enumeration myEnum = { one, two, three }
 rule foo =
 {
     let x : Tuple< Integer, Integer > = [ 1, 10 ] in
-    	assert( x as myEnum = myEnum.one ) //@ ERROR( 1700 )
+    	assert( x as myEnum = myEnum::one ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/integer/error/enumeration.casm
+++ b/test/expression/typecasting/integer/error/enumeration.casm
@@ -46,6 +46,6 @@ enumeration myEnum = { one, two, three }
 
 rule foo =
 {
-    let x : myEnum = myEnum.two in
+    let x : myEnum = myEnum::two in
         assert( x as Integer = 2 ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/rational/error/enumeration.casm
+++ b/test/expression/typecasting/rational/error/enumeration.casm
@@ -46,6 +46,6 @@ enumeration myEnum = { one, two, three }
 
 rule foo =
 {
-    let x : myEnum = myEnum.two in
+    let x : myEnum = myEnum::two in
         assert( x as Rational = 0r0/1 ) //@ ERROR( 1700 )
 }

--- a/test/expression/typecasting/string/enumeration.casm
+++ b/test/expression/typecasting/string/enumeration.casm
@@ -46,8 +46,8 @@ enumeration myEnum = { one, two, three }
 
 rule foo =
 {
-    let x : myEnum = undef        in assert( x as String = undef )
-    let x : myEnum = myEnum.one   in assert( x as String = "one" )
-    let x : myEnum = myEnum.two   in assert( x as String = "two" )
-    let x : myEnum = myEnum.three in assert( x as String = "three" )
+    let x : myEnum = undef         in assert( x as String = undef )
+    let x : myEnum = myEnum::one   in assert( x as String = "one" )
+    let x : myEnum = myEnum::two   in assert( x as String = "two" )
+    let x : myEnum = myEnum::three in assert( x as String = "three" )
 }

--- a/test/rule/choose/enumeration_universe.casm
+++ b/test/rule/choose/enumeration_universe.casm
@@ -54,9 +54,9 @@ rule foo =
     choose i in Color do
         case i of
         {
-            .Red: skip
-            .Green: skip
-            .Blue: skip
+            ::Red: skip
+            ::Green: skip
+            ::Blue: skip
             _: assert( false )
         }
 

--- a/test/rule/let/variable_name_same_as_relative_enumerator_name.casm
+++ b/test/rule/let/variable_name_same_as_relative_enumerator_name.casm
@@ -45,6 +45,6 @@ CASM init foo
 enumeration Color = { Blue, Red, Green }
 
 rule foo =
-    let Red = Color.Red in
-        let c = .Red in  // uses variable Red if buggy
+    let Red = Color::Red in
+        let c = ::Red in  // uses variable Red if buggy
             skip

--- a/test/symtbl/enumeration_uses.casm
+++ b/test/symtbl/enumeration_uses.casm
@@ -47,9 +47,9 @@ enumeration ABC = { A, B, C }
 
 rule foo =
 {
-    let x = ABC.A in skip
+    let x = ABC::A in skip
 
-    let x : ABC = ABC.B in skip
+    let x : ABC = ABC::B in skip
 
-    let x : ABC = .C in skip
+    let x : ABC = ::C in skip
 }


### PR DESCRIPTION
missing unit test cases changed related to the PRs:
- casm-lang/libcasm-fe#107
- casm-lang/libcasm-fe#106
- casm-lang/libcasm-fe#105
