### PR TITLE
[application] Add a Prisoners game specification

### DIFF
--- a/application/Prisoners.casm
+++ b/application/Prisoners.casm
@@ -1,0 +1,120 @@
+//
+//  Copyright (c) 2014-2017 CASM Organization
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                https://github.com/casm-lang/libcasm-tc
+//
+//  This file is part of libcasm-tc.
+//
+//  libcasm-tc is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libcasm-tc is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libcasm-tc. If not, see <http://www.gnu.org/licenses/>.
+//
+//  Additional permission under GNU GPL version 3 section 7
+//
+//  libcasm-tc is distributed under the terms of the GNU General Public License
+//  with the following clarification and special exception: Linking libcasm-tc
+//  statically or dynamically with other modules is making a combined work
+//  based on libcasm-tc. Thus, the terms and conditions of the GNU General
+//  Public License cover the whole combination. As a special exception,
+//  the copyright holders of libcasm-tc give you permission to link libcasm-tc
+//  with independent modules to produce an executable, regardless of the
+//  license terms of these independent modules, and to copy and distribute
+//  the resulting executable under terms of your choice, provided that you
+//  also meet, for each linked independent module, the terms and conditions
+//  of the license of that module. An independent module is a module which
+//  is not derived from or based on libcasm-tc. If you modify libcasm-tc, you
+//  may extend this exception to your version of the library, but you are
+//  not obliged to do so. If you do not wish to do so, delete this exception
+//  statement from your version.
+//
+
+/*
+ * Prisoners Game:
+ *
+ * There are 100 prisoners in solitary cells. There’s a central living room with
+ * one light bulb; this bulb is initially off. No prisoner can see the light
+ * bulb from his or her own cell. Every day, the warden picks a prisoner equally
+ * at random, and that prisoner visits the living room. While there, the
+ * prisoner can toggle the bulb if he or she wishes. Also, the prisoner has the
+ * option of asserting that all 100 prisoners have been to the living room by
+ * now. If this assertion is false, all 100 prisoners are shot. If it is true,
+ * however, all prisoners are set free. Thus, the assertion should only be made
+ * if the prisoner is certain of its validity. The prisoners are allowed to get
+ * together on the first night to discuss a plan. Once they’ve agreed on a plan,
+ * the game starts and they can’t meet again.
+ */
+
+CASM init DiscussPlan
+
+using Prisoner = Integer'[1..100]
+
+enumeration BulbState = { On, Off }
+
+function lightBulb : -> BulbState initially { ::Off }
+function lightToggleCounter : Prisoner -> Integer defined { 0 }
+function leadingPrisoner : -> Prisoner
+
+// FIXME: `days` is more or less a workaround to keep it running.
+// Problem: `VisitLivingRoom` requires a different abort-condition.
+// Fix: Make it possible to specify the required abort-condition.
+function days : -> Integer initially { 0 }
+
+derived visitedLivingRoom( prisoner : Prisoner ) -> Boolean =
+    lightToggleCounter( prisoner ) > 0
+
+rule DiscussPlan =
+{
+    choose prisoner in Prisoner do
+        leadingPrisoner := prisoner
+
+    program( self ) := @VisitLivingRoom
+}
+
+rule VisitLivingRoom =
+{
+    choose prisoner in Prisoner do {
+        if prisoner = leadingPrisoner and lightBulb = ::On then {
+            lightBulb := ::Off
+
+            {|
+                lightToggleCounter( prisoner ) := lightToggleCounter( prisoner ) + 1
+                if lightToggleCounter( prisoner ) = 99 then // TODO replace 99 by something like Prisoner'last - 1
+                    program( self ) := @AssertAllPrisonersHaveBeenInTheLivingRoom
+            |}
+        }
+
+        if prisoner != leadingPrisoner and lightBulb = ::Off and not visitedLivingRoom( prisoner ) then {
+            lightBulb := ::On
+
+            assert( lightToggleCounter( prisoner ) = 0 )
+            lightToggleCounter( prisoner ) := 1
+        }
+    }
+
+    days := days + 1
+}
+
+rule AssertAllPrisonersHaveBeenInTheLivingRoom =
+{
+    if forall prisoner in Prisoner holds visitedLivingRoom( prisoner ) then {
+        println( "All prisoners are freed." )
+    } else {
+        println( "All prisoners are shot." )
+    }
+
+    println( "Took " + days as String + " days." )
+
+    program( self ) := undef
+}


### PR DESCRIPTION
There are 100 prisoners in solitary cells. There’s a central living room with
one light bulb; this bulb is initially off. No prisoner can see the light bulb
from his or her own cell. Every day, the warden picks a prisoner equally at
random, and that prisoner visits the living room. While there, the prisoner can
toggle the bulb if he or she wishes. Also, the prisoner has the option of
asserting that all 100 prisoners have been to the living room by now. If this
assertion is false, all 100 prisoners are shot. If it is true, however, all
prisoners are set free. Thus, the assertion should only be made if the prisoner
is certain of its validity. The prisoners are allowed to get together on the
first night to discuss a plan. Once they’ve agreed on a plan, the game starts
and they can’t meet again.