### PR TITLE
[grammar] Parsing error when using call without arguments and relative path in combination

### DIFF
--- a/test/grammar/call_without_arguments_and_relative_path_in_case_rule.casm
+++ b/test/grammar/call_without_arguments_and_relative_path_in_case_rule.casm
@@ -1,0 +1,67 @@
+//
+//  Copyright (c) 2014-2018 CASM Organization <https://casm-lang.org>
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                <https://github.com/casm-lang/libcasm-tc>
+//
+//  This file is part of libcasm-tc.
+//
+//  libcasm-tc is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libcasm-tc is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libcasm-tc. If not, see <http://www.gnu.org/licenses/>.
+//
+//  Additional permission under GNU GPL version 3 section 7
+//
+//  libcasm-tc is distributed under the terms of the GNU General Public License
+//  with the following clarification and special exception: Linking libcasm-tc
+//  statically or dynamically with other modules is making a combined work
+//  based on libcasm-tc. Thus, the terms and conditions of the GNU General
+//  Public License cover the whole combination. As a special exception,
+//  the copyright holders of libcasm-tc give you permission to link libcasm-tc
+//  with independent modules to produce an executable, regardless of the
+//  license terms of these independent modules, and to copy and distribute
+//  the resulting executable under terms of your choice, provided that you
+//  also meet, for each linked independent module, the terms and conditions
+//  of the license of that module. An independent module is a module which
+//  is not derived from or based on libcasm-tc. If you modify libcasm-tc, you
+//  may extend this exception to your version of the library, but you are
+//  not obliged to do so. If you do not wish to do so, delete this exception
+//  statement from your version.
+//
+
+/**
+ * The problem was, that the parser treated the bar rule call and the
+ * immediately following relative path ::Blue as a single absolute path
+ * bar::Blue.
+ *
+ * Thus the case expression is missing because the wrongly interpreted absolute
+ * path is a call without args which belongs to the previous case. And so the
+ * unexpected colon error was thrown.
+ *
+ * See https://github.com/casm-lang/casm/issues/59
+*/
+
+CASM init foo
+
+enumeration Color = { Red, Green, Blue }
+
+rule bar =
+    skip
+
+rule foo =
+    choose c in Color do
+        case c of {
+            ::Red: bar
+            ::Blue: skip // error happened here "unexpected :" after ::Blue
+        }


### PR DESCRIPTION
See casm-lang/casm#59