### PR TITLE
[application] Brainfuck Interpreter: Some additional changes/cleanups

### DIFF
--- a/application/Brain****Machine.casm
+++ b/application/Brain****Machine.casm
@@ -324,7 +324,7 @@ rule Jump(step: RuleRef<-> Void>, initialBracketCount: Integer) =
             {
                 ::LeftParen:  bc := bc + 1
                 ::RightParen: bc := bc - 1
-                undef:        assert(false) // bf syntax error: branch mismatch
+                undef:        abort // bf syntax error: branch mismatch
             }
         |}
     }


### PR DESCRIPTION
* Inject step rule into Jump to make it easier to read (less let + less nesting)
* Use `abort` instead of `asset(false)` 
* Fix the `mem` function FIXME