### PR TITLE
Implies Operator: fixed incorrect assertions

### DIFF
--- a/test/operator/imp/00.casm
+++ b/test/operator/imp/00.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != true )
         assert( c.isSymbolic() = false )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/01.casm
+++ b/test/operator/imp/01.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != true )
         assert( c.isSymbolic() = false )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/02.casm
+++ b/test/operator/imp/02.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != false )
         assert( c.isSymbolic() = false )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/03.casm
+++ b/test/operator/imp/03.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != false )
         assert( c != true )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/10.casm
+++ b/test/operator/imp/10.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != false )
         assert( c.isSymbolic() = false )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/11.casm
+++ b/test/operator/imp/11.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != false )
         assert( c.isSymbolic() = false )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/12.casm
+++ b/test/operator/imp/12.casm
@@ -41,12 +41,12 @@
 //
 
 
-// | IMP   | undef | false | true  | sym  |
-// |-------+-------+-------+-------+------|
-// | undef | undef | true  | undef | sym' |
-// | false | undef | true  | false | sym' |
-// | true  | true  | true  | true  | true |
-// | sym   | sym'  | true  | sym'  | sym' |
+// | IMP   | undef | false | true  | sym   |
+// |-------+-------+-------+-------+-------|
+// | undef | undef | undef | true  | sym'  |
+// | false | true  | true  | true  | true  |
+// | true  | undef | false | true  | sym'  |
+// | sym   | sym'  | sym'  | true  | sym'  |
 
 CASM init foo
 
@@ -56,12 +56,12 @@ rule foo =
     let b = true  in
     let c = a implies b in
     {
-        assert( c  = false )
+        assert( c  = true )
         
         assert( c != undef )
-        assert( c != true )
+        assert( c != false )
         assert( c.isSymbolic() = false )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/13.casm
+++ b/test/operator/imp/13.casm
@@ -63,6 +63,6 @@ rule foo =
         assert( c != false )
         assert( c.isSymbolic() = false )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/20.casm
+++ b/test/operator/imp/20.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != false )
         assert( c.isSymbolic() = false )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/21.casm
+++ b/test/operator/imp/21.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != true )
         assert( c.isSymbolic() = false )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/22.casm
+++ b/test/operator/imp/22.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != false )
         assert( c.isSymbolic() = false )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/23.casm
+++ b/test/operator/imp/23.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != false )
         assert( c != true )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/30.casm
+++ b/test/operator/imp/30.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != false )
         assert( c != true )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/31.casm
+++ b/test/operator/imp/31.casm
@@ -62,6 +62,6 @@ rule foo =
         assert( c != false )
         assert( c != true )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/32.casm
+++ b/test/operator/imp/32.casm
@@ -63,6 +63,6 @@ rule foo =
         assert( c != false )
         assert( c.isSymbolic() = false )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }

--- a/test/operator/imp/33.casm
+++ b/test/operator/imp/33.casm
@@ -63,6 +63,6 @@ rule foo =
         assert( c != false )
         assert( c != true )
 
-        assert( c = a => b )
+        assert( c = (a => b) )
     }
 }


### PR DESCRIPTION
* due to operator precedence the asserts in form `assert( c = a => b )`
  resulted in a `undef` value which was correct but in this case the
  unit test failed, because the correct tested behavior would be
  `assert( c = ( a => b ) )`
* test case `test/operator/imp/12.casm` had still an old format table,
  updated it to be conform to other test cases
* related to casm-lang/casm#53
