### PR TITLE
Tuple Literal: fixed missing error code for accessing unknown tuple elements

### DIFF
--- a/test/type/tuple/error/element_access_named_of_type_named.casm
+++ b/test/type/tuple/error/element_access_named_of_type_named.casm
@@ -51,21 +51,21 @@ rule foo =
     let
     a : Integer
     =
-    bar.a //@ ERROR( ? )
+    bar.a //@ ERROR( 0507 )
     in
     	skip
 
     let
     a : String
     =
-    bar.b //@ ERROR( ? )
+    bar.b //@ ERROR( 0507 )
     in
     	skip
 
     let
     a : Decimal
     =
-    bar.c //@ ERROR( ? )
+    bar.c //@ ERROR( 0507 )
     in
     	skip
 }


### PR DESCRIPTION
* related to casm-lang/libcasm-tc#68
