### PR TITLE
Bug/afl crashes

### DIFF
--- a/test/definition/init/error/multiple_definition.casm
+++ b/test/definition/init/error/multiple_definition.casm
@@ -43,7 +43,7 @@
 
 CASM
 
-init foo //@ERROR( a001 )
+init foo
 
 rule foo = skip
 

--- a/test/definition/init/error/multiple_definition.casm
+++ b/test/definition/init/error/multiple_definition.casm
@@ -43,7 +43,7 @@
 
 CASM
 
-init foo //@ERROR( a001 ) //@DISABLED()
+init foo //@ERROR( a001 )
 
 rule foo = skip
 

--- a/test/expression/call/direct/error/function_with_invalid_argument.casm
+++ b/test/expression/call/direct/error/function_with_invalid_argument.casm
@@ -40,8 +40,9 @@
 //  statement from your version.
 //
 
+// shall throw an error that 'Self' identifier does not exist!
+
 CASM init test
 
 rule test =
-    program( Self ) := undef
-
+    program( Self ) := undef //@ ERROR( 0500 )

--- a/test/issue/afl0.casm
+++ b/test/issue/afl0.casm
@@ -1,0 +1,47 @@
+//
+//  Copyright (C) 2014-2019 CASM Organization <https://casm-lang.org>
+//  All rights reserved.
+//
+//  Developed by: Philipp Paulweber
+//                Emmanuel Pescosta
+//                <https://github.com/casm-lang/libcasm-tc>
+//
+//  This file is part of libcasm-tc.
+//
+//  libcasm-tc is free software: you can redistribute it and/or modify
+//  it under the terms of the GNU General Public License as published by
+//  the Free Software Foundation, either version 3 of the License, or
+//  (at your option) any later version.
+//
+//  libcasm-tc is distributed in the hope that it will be useful,
+//  but WITHOUT ANY WARRANTY; without even the implied warranty of
+//  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+//  GNU General Public License for more details.
+//
+//  You should have received a copy of the GNU General Public License
+//  along with libcasm-tc. If not, see <http://www.gnu.org/licenses/>.
+//
+//  Additional permission under GNU GPL version 3 section 7
+//
+//  libcasm-tc is distributed under the terms of the GNU General Public License
+//  with the following clarification and special exception: Linking libcasm-tc
+//  statically or dynamically with other modules is making a combined work
+//  based on libcasm-tc. Thus, the terms and conditions of the GNU General
+//  Public License cover the whole combination. As a special exception,
+//  the copyright holders of libcasm-tc give you permission to link libcasm-tc
+//  with independent modules to produce an executable, regardless of the
+//  license terms of these independent modules, and to copy and distribute
+//  the resulting executable under terms of your choice, provided that you
+//  also meet, for each linked independent module, the terms and conditions
+//  of the license of that module. An independent module is a module which
+//  is not derived from or based on libcasm-tc. If you modify libcasm-tc, you
+//  may extend this exception to your version of the library, but you are
+//  not obliged to do so. If you do not wish to do so, delete this exception
+//  statement from your version.
+//
+
+CASM init test
+
+rule test =
+    program( Self ) := undef
+


### PR DESCRIPTION
- provides missing test cases related to detected `afl-fuzz` crashes
- related to casm-lang/casm#95
- related to casm-lang/casm#96
